### PR TITLE
implements functionality to allow updating of address associate with a credit card

### DIFF
--- a/app/controllers/spree/creditcards_controller.rb
+++ b/app/controllers/spree/creditcards_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   class CreditcardsController < Spree::BaseController
     ssl_allowed
-    respond_to :js
+    respond_to :js, :html
 
     def destroy
       @creditcard = Spree::Creditcard.find(params["id"])
@@ -16,7 +16,21 @@ module Spree
       else
         render template: 'spree/creditcards/destroy_error'
       end
+    end
 
+    def edit
+      @creditcard = Spree::Creditcard.find(params[:id])
+      @address = @creditcard.address.dup
+    end
+
+    def update
+      @creditcard = Spree::Creditcard.find(params[:id])
+
+      if @creditcard.update_address(params[:address])
+        flash[:notice] = I18n.t(:successfully_updated, :resource => I18n.t(:address))
+      else
+      end
+      redirect_back_or_default(account_path)
     end
   end
 end

--- a/app/views/spree/creditcards/edit.html.erb
+++ b/app/views/spree/creditcards/edit.html.erb
@@ -1,0 +1,98 @@
+<style>
+  form p.field input[type=text], form p.field select { width: 80%; float: none; }
+  .hidden { display: none; }
+  div.inner label { width: auto; padding-right: 5px; display: inline-block; }
+  form p.field span.req { float: none; }
+</style>
+<%= form_for @creditcard do |f| %>
+  <%= fields_for "address", @address do |address_fields| %>
+    <fieldset>
+      <div class="inner">
+        <legend><%= t(:billing_address) %></legend>
+        <div class="inner" data-hook="billing_inner">
+          <p class="field" id="bis_business">
+            <%= label_tag :is_business, t(:is_business) %>
+            <%= address_fields.radio_button :is_business, true -%>&nbsp;<%= t(:yes) -%>&nbsp;&nbsp;
+            <%= address_fields.radio_button :is_business, false -%>&nbsp;<%= t(:no) -%>
+          </p>
+          <p class="field" id="bfirstname">
+            <%= label_tag :firstname, t(:first_name) %><span class="req">*</span><br />
+            <%= address_fields.text_field :firstname, :class => 'required' %>
+          </p>
+          <p class="field" id="blastname">
+            <%= label_tag :lastname, t(:last_name) %><span class="req">*</span><br />
+            <%= address_fields.text_field :lastname, :class => 'required' %>
+          </p>
+          <% if Spree::Config[:company] %>
+            <p class="field" id="bcompany">
+              <%= label_tag :company, t(:company) %><br />
+              <%= address_fields.text_field :company %>
+            </p>
+          <% end %>
+          <p class="field" id="baddress1">
+            <%= label_tag :address1, t(:street_address) %><span class="req">*</span><br />
+            <%= address_fields.text_field :address1, :class => 'required' %>
+          </p>
+          <p class="field" id="baddress2">
+            <%= label_tag :address2, t(:street_address_2) %><br />
+            <%= address_fields.text_field :address2 %>
+          </p>
+
+          <p class="field" id="bcountry">
+            <%= label_tag :country_id, t(:country) %><span class="req">*</span><br />
+            <span id="bcountry">
+              <%= address_fields.collection_select :country_id, available_countries, :id, :name, {}, {:class => 'required'} %>
+            </span>
+          </p>
+
+          <% if Spree::Config[:address_requires_state] %>
+            <p class="field" id="bstate">
+              <% have_states = (@address.country.present? && @address.country.states.present?) %>
+              <%= address_fields.label :state, t(:state) %><span class="req">*</span><br />
+              <noscript>
+                <%= address_fields.text_field :state_name, :class => 'required' %>
+              </noscript>
+              <% state_elements = [
+                   address_fields.collection_select(:state_id, @address.country.states,
+                                      :id, :name,
+                                      {:include_blank => true},
+                                      {:class => have_states ? 'required' : 'hidden',
+                                      :disabled => !have_states}) +
+                   address_fields.text_field(:state_name,
+                                      :class => !have_states ? 'required' : 'hidden',
+                                      :disabled => have_states)
+                   ].join.gsub('"', "'").gsub("\n", "")
+              %>
+              <%= javascript_tag do -%>
+                document.write("<%== state_elements %>");
+              <% end -%>
+            </p>
+          <% end %>
+
+          <p class="field" id="bcity">
+            <%= label_tag :city, t(:city) %><span class="req">*</span><br />
+            <%= address_fields.text_field :city, :class => 'required' %>
+          </p>
+
+          <p class="field" id="bzipcode">
+            <%= label_tag :zipcode, t(:zip) %><span class="req">*</span><br />
+            <%= address_fields.text_field :zipcode, :class => 'required digits' %>
+          </p>
+          <p class="field" id="bphone">
+            <%= label_tag :phone, t(:phone) %><span class="req">*</span><br />
+            <%= address_fields.text_field :phone, :class => 'required' %>
+          </p>
+          <% if Spree::Config[:alternative_billing_phone] %>
+            <p class="field" id="baltphone">
+              <%= label_tag :alternative_phone, t(:alternative_phone) %><br />
+              <%= address_fields.text_field :alternative_phone %>
+            </p>
+          <% end %>
+
+        </div>
+      </div>
+      <%= f.submit t(:update) %>
+    </fieldset>
+  <% end %>
+<% end %>
+

--- a/app/views/spree/users/_card_admin.html.erb
+++ b/app/views/spree/users/_card_admin.html.erb
@@ -20,6 +20,7 @@
           <th>Expiration</th>
           <th>Billing Address</th>
           <th></th>
+          <th></th>
         </tr>
       </thead>
       <tbody>
@@ -28,13 +29,15 @@
             <td align="center"><%= card.name %></td>
             <td align="center"><%= card.display_number %></td>
             <td align="center"><%= "#{card.month}/#{card.year}" %></td>
-			<td align="center"><%= card.address %></td>
+			      <td align="center"><%= card.address %></td>
             <td>
             <%= link_to (icon('delete') + ' ' + t(:delete)),
                 spree.creditcard_url(card),
                 remote: true, method: :delete,
                 confirm: 'Are you sure?' %>
             </td>
+            <td>
+            <%= link_to (icon('edit') + ' ' + t(:edit)), spree.edit_creditcard_url(card) %></td>
           </tr>
         <% end %>
       </tbody>


### PR DESCRIPTION
- when User updates a card's address, a new Address object is
  instantiated based on the values passed in from the form
- if the resulting Address object matches an existing Address for
  that Creditcard, then nothing happens (e.g., if the user just
  submits the form without changing any of the address info)
- if the Address object doesn't match an existing address for that
  Creditcard, then the Address is saved and the Creditcard is updated
  so that it's address_id is that of the newly created Address object
